### PR TITLE
Add states with no role information

### DIFF
--- a/boundaries/build/index.json
+++ b/boundaries/build/index.json
@@ -40,5 +40,40 @@
       "lang:hi": "NAME_HI",
       "lang:en": "PC_NAME"
     }
+  },
+  {
+    "directory": "states",
+    "area_type_wikidata_item_id": "Q13390680",
+    "associations": [],
+    "name_columns": {
+      "lang:hi": "NAME_HI",
+      "lang:en": "ST_NM"
+    },
+    "filter": {
+      "match": "country:in/state",
+      "column": "MS_FB"
+    }
+  },
+  {
+    "directory": "states",
+    "area_type_wikidata_item_id": "Q467745",
+    "associations": [],
+    "name_columns": {
+      "lang:hi": "NAME_HI",
+      "lang:en": "ST_NM"
+    },
+    "filter": {
+      "match": "country:in/territory",
+      "column": "MS_FB"
+    }
+  },
+  {
+    "directory": "territories",
+    "area_type_wikidata_item_id": "Q467745",
+    "associations": [],
+    "name_columns": {
+      "lang:hi": "NAME_HI",
+      "lang:en": "ST_NM"
+    }
   }
 ]

--- a/boundaries/build/territories/territories.csv
+++ b/boundaries/build/territories/territories.csv
@@ -1,0 +1,2 @@
+ST_NM,TYPE,MS_FB,MS_FB_PARE,WIKIDATA,NAME_HI
+Andaman and Nicobar Islands,Union Territory,country:in/territory:an,country:in,Q40888,अण्डमान और निकोबार द्वीपसमूह

--- a/legislative/Q230003/Q15978395/popolo-m17n.json
+++ b/legislative/Q230003/Q15978395/popolo-m17n.json
@@ -10412,6 +10412,31 @@
   ],
   "areas": [
     {
+      "id": "Q1061",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:gj"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1061"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "गुजरात",
+        "lang:en": "Gujarat"
+      },
+      "parent_id": "Q668"
+    },
+    {
       "id": "Q11031937",
       "identifiers": [
         {
@@ -10434,7 +10459,7 @@
         "lang:hi": "सलेमपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Salempur"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q11032972",
@@ -10459,7 +10484,7 @@
         "lang:hi": "कानपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kanpur"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q11059079",
@@ -10484,7 +10509,7 @@
         "lang:hi": "क्योंझर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Keonjhar"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q11222818",
@@ -10509,7 +10534,107 @@
         "lang:hi": "राजकोट लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Rajkot"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
+    },
+    {
+      "id": "Q1159",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:ap"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1159"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "आन्ध्र प्रदेश",
+        "lang:en": "Andhra Pradesh"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1162",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:ar"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1162"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "अरुणाचल प्रदेश",
+        "lang:en": "Arunachal Pradesh"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1164",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:as"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1164"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "असम",
+        "lang:en": "Assam"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1165",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:br"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1165"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "बिहार",
+        "lang:en": "Bihar"
+      },
+      "parent_id": "Q668"
     },
     {
       "id": "Q11679513",
@@ -10534,7 +10659,307 @@
         "lang:hi": "कंधमाल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kandhamal"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
+    },
+    {
+      "id": "Q1168",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:ct"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1168"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "छत्तीसगढ़",
+        "lang:en": "Chhattisgarh"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1171",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:ga"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1171"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "गोआ",
+        "lang:en": "Goa"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1174",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:hr"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1174"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "हरियाणा",
+        "lang:en": "Haryana"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1177",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:hp"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1177"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "हिमाचल प्रदेश",
+        "lang:en": "Himachal Pradesh"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1180",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:jk"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1180"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "जम्मू और कश्मीर",
+        "lang:en": "Jammu and Kashmir"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1184",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:jh"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1184"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "झारखण्ड",
+        "lang:en": "Jharkhand"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1185",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:ka"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1185"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "कर्नाटक",
+        "lang:en": "Karnataka"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1186",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:kl"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1186"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "केरल",
+        "lang:en": "Kerala"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1188",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:mp"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1188"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "मध्य प्रदेश",
+        "lang:en": "Madhya Pradesh"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1191",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:mh"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1191"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "महाराष्ट्र",
+        "lang:en": "Maharashtra"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1193",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:mn"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1193"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "मणिपुर",
+        "lang:en": "Manipur"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1195",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:ml"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1195"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "मेघालय",
+        "lang:en": "Meghalaya"
+      },
+      "parent_id": "Q668"
     },
     {
       "id": "Q12413298",
@@ -10559,7 +10984,7 @@
         "lang:hi": "अट्टिंगल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Attingal"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q12416142",
@@ -10584,7 +11009,7 @@
         "lang:hi": "उत्तर गोवा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "North Goa"
       },
-      "parent_id": null
+      "parent_id": "Q1171"
     },
     {
       "id": "Q12418036",
@@ -10609,7 +11034,7 @@
         "lang:hi": "कन्नौज लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kannauj"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q12418045",
@@ -10634,7 +11059,7 @@
         "lang:hi": "कन्याकुमारी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kanyakumari"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q12418918",
@@ -10659,7 +11084,7 @@
         "lang:hi": "कांकेर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kanker"
       },
-      "parent_id": null
+      "parent_id": "Q1168"
     },
     {
       "id": "Q12418931",
@@ -10684,7 +11109,7 @@
         "lang:hi": "कांचीपुरम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kancheepuram"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q12419668",
@@ -10709,7 +11134,7 @@
         "lang:hi": "किशनगंज लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kishanganj"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q12420304",
@@ -10734,7 +11159,7 @@
         "lang:hi": "कुशीनगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kushi Nagar"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q12420818",
@@ -10759,7 +11184,7 @@
         "lang:hi": "कैराना लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kairana"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q12423118",
@@ -10784,7 +11209,7 @@
         "lang:hi": "गढ़चिरौली-चिमूर (लोक सभा निर्वाचन क्षेत्र)",
         "lang:en": "Gadchiroli-Chimur"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q12424329",
@@ -10809,7 +11234,7 @@
         "lang:hi": "गोंडा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Gonda"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q12428079",
@@ -10834,7 +11259,7 @@
         "lang:hi": "जमुई लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jamui"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q12428505",
@@ -10859,7 +11284,7 @@
         "lang:hi": "जहानाबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jahanabad"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q12428678",
@@ -10884,7 +11309,7 @@
         "lang:hi": "यादवपुर",
         "lang:en": "Jadavpur"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q12433303",
@@ -10909,7 +11334,7 @@
         "lang:hi": "दमोह लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Damoh"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q12434696",
@@ -10934,7 +11359,7 @@
         "lang:hi": "धौरहरा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dhaurahra"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q12446106",
@@ -10959,7 +11384,7 @@
         "lang:hi": "महासमुन्द लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mahasamund"
       },
-      "parent_id": null
+      "parent_id": "Q1168"
     },
     {
       "id": "Q12446954",
@@ -10984,7 +11409,7 @@
         "lang:hi": "मुंबई - दक्षिण लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mumbai South"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q12447565",
@@ -11009,7 +11434,7 @@
         "lang:hi": "मेरठ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Meerut"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q12448769",
@@ -11034,7 +11459,7 @@
         "lang:hi": "रत्नागिरि-सिंधुदुर्ग लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ratnagiri-Sindhudurg"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q12449852",
@@ -11059,7 +11484,7 @@
         "lang:hi": "रायगंज लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Raiganj"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q12449885",
@@ -11084,7 +11509,7 @@
         "lang:hi": "रायपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Raipur"
       },
-      "parent_id": null
+      "parent_id": "Q1168"
     },
     {
       "id": "Q12453868",
@@ -11109,7 +11534,7 @@
         "lang:hi": "शहडोल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Shahdol"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q12455246",
@@ -11134,7 +11559,7 @@
         "lang:hi": "सतना",
         "lang:en": "Satna"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q12457988",
@@ -11159,7 +11584,7 @@
         "lang:hi": "सुपौल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Supaul"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q12460207",
@@ -11184,7 +11609,7 @@
         "lang:hi": "हातकणंगले लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Hatkanangle"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q12460611",
@@ -11209,7 +11634,7 @@
         "lang:hi": "हिसार लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Hisar"
       },
-      "parent_id": null
+      "parent_id": "Q1174"
     },
     {
       "id": "Q12460669",
@@ -11234,7 +11659,7 @@
         "lang:hi": "हुगली लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Hooghly"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q13118215",
@@ -11259,7 +11684,7 @@
         "lang:hi": "नई दिल्ली लोकसभा निर्वाचन क्षेत्र",
         "lang:en": "New Delhi"
       },
-      "parent_id": null
+      "parent_id": "Q1353"
     },
     {
       "id": "Q13512172",
@@ -11284,7 +11709,7 @@
         "lang:hi": "कोल्हापुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kolhapur"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q13512175",
@@ -11309,7 +11734,232 @@
         "lang:hi": "खीरी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kheri"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
+    },
+    {
+      "id": "Q1353",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/territory:dl"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1353"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "union territory of India",
+        "lang:hi": "भारत के संघ राज्यक्षेत्र"
+      },
+      "name": {
+        "lang:hi": "दिल्ली",
+        "lang:en": "Delhi"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1356",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:wb"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1356"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "पश्चिम बंगाल",
+        "lang:en": "West Bengal"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1363",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:tr"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1363"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "त्रिपुरा",
+        "lang:en": "Tripura"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1437",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:rj"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1437"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "राजस्थान",
+        "lang:en": "Rajasthan"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1445",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:tn"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1445"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "तमिल नाडु",
+        "lang:en": "Tamil Nadu"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1498",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:up"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1498"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "उत्तर प्रदेश",
+        "lang:en": "Uttar Pradesh"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1499",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:ut"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1499"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "उत्तराखण्ड",
+        "lang:en": "Uttarakhand"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1502",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:mz"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1502"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "मिज़ोरम",
+        "lang:en": "Mizoram"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q1505",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:sk"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1505"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "सिक्किम",
+        "lang:en": "Sikkim"
+      },
+      "parent_id": "Q668"
     },
     {
       "id": "Q15649259",
@@ -11334,7 +11984,32 @@
         "lang:hi": "देवास लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dewas"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
+    },
+    {
+      "id": "Q1599",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:nl"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q1599"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "नागालैण्ड",
+        "lang:en": "Nagaland"
+      },
+      "parent_id": "Q668"
     },
     {
       "id": "Q1606595",
@@ -11359,7 +12034,7 @@
         "lang:hi": "नौगांव लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nowgong"
       },
-      "parent_id": null
+      "parent_id": "Q1164"
     },
     {
       "id": "Q1606606",
@@ -11384,7 +12059,7 @@
         "lang:hi": "बारपेटा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Barpeta"
       },
-      "parent_id": null
+      "parent_id": "Q1164"
     },
     {
       "id": "Q1606616",
@@ -11409,7 +12084,7 @@
         "lang:hi": "धुबरी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dhubri"
       },
-      "parent_id": null
+      "parent_id": "Q1164"
     },
     {
       "id": "Q1606626",
@@ -11434,7 +12109,7 @@
         "lang:hi": "सिल्चर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Silchar"
       },
-      "parent_id": null
+      "parent_id": "Q1164"
     },
     {
       "id": "Q1606633",
@@ -11459,7 +12134,7 @@
         "lang:hi": "गुवाहाटी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Gauhati"
       },
-      "parent_id": null
+      "parent_id": "Q1164"
     },
     {
       "id": "Q1606642",
@@ -11484,7 +12159,7 @@
         "lang:hi": "कलियाबोर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kaliabor"
       },
-      "parent_id": null
+      "parent_id": "Q1164"
     },
     {
       "id": "Q1606654",
@@ -11509,7 +12184,7 @@
         "lang:hi": "मंगलदोई लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mangaldoi"
       },
-      "parent_id": null
+      "parent_id": "Q1164"
     },
     {
       "id": "Q1606665",
@@ -11534,7 +12209,7 @@
         "lang:hi": "करीमगंज लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Karimganj"
       },
-      "parent_id": null
+      "parent_id": "Q1164"
     },
     {
       "id": "Q1606670",
@@ -11559,7 +12234,7 @@
         "lang:hi": "कोकराझार लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kokrajhar"
       },
-      "parent_id": null
+      "parent_id": "Q1164"
     },
     {
       "id": "Q1606679",
@@ -11584,7 +12259,7 @@
         "lang:hi": "स्वशासी जिला-असम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Autonomous District"
       },
-      "parent_id": null
+      "parent_id": "Q1164"
     },
     {
       "id": "Q1606690",
@@ -11609,7 +12284,7 @@
         "lang:hi": "डिब्रुगढ़ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dibrugarh"
       },
-      "parent_id": null
+      "parent_id": "Q1164"
     },
     {
       "id": "Q1606703",
@@ -11634,7 +12309,7 @@
         "lang:hi": "तेजपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Tezpur"
       },
-      "parent_id": null
+      "parent_id": "Q1164"
     },
     {
       "id": "Q1609659",
@@ -11659,7 +12334,7 @@
         "lang:hi": "लखीमपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Lakhimpur"
       },
-      "parent_id": null
+      "parent_id": "Q1164"
     },
     {
       "id": "Q16193457",
@@ -11684,7 +12359,7 @@
         "lang:hi": "आज़मगढ़ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Azamgarh (Lok Sabha constituency)"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q1659299",
@@ -11709,7 +12384,7 @@
         "lang:hi": "मिज़ोरम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mizoram"
       },
-      "parent_id": null
+      "parent_id": "Q1502"
     },
     {
       "id": "Q1659305",
@@ -11734,7 +12409,7 @@
         "lang:hi": "अरुणाचल पश्चिम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Arunachal West"
       },
-      "parent_id": null
+      "parent_id": "Q1162"
     },
     {
       "id": "Q1659313",
@@ -11759,7 +12434,7 @@
         "lang:hi": "नागालैंड लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nagaland"
       },
-      "parent_id": null
+      "parent_id": "Q1599"
     },
     {
       "id": "Q1659321",
@@ -11784,7 +12459,7 @@
         "lang:hi": "सिक्किम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sikkim"
       },
-      "parent_id": null
+      "parent_id": "Q1505"
     },
     {
       "id": "Q1659329",
@@ -11809,7 +12484,7 @@
         "lang:hi": "अरुणाचल पूर्व लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Arunachal East"
       },
-      "parent_id": null
+      "parent_id": "Q1162"
     },
     {
       "id": "Q1780136",
@@ -11834,7 +12509,57 @@
         "lang:hi": "बांदा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Banda"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
+    },
+    {
+      "id": "Q22048",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:or"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q22048"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "ओडिशा",
+        "lang:en": "Odisha"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q22424",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:pb"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q22424"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "पंजाब",
+        "lang:en": "Punjab"
+      },
+      "parent_id": "Q668"
     },
     {
       "id": "Q255234",
@@ -11859,7 +12584,7 @@
         "lang:hi": "सरगुजा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Surguja"
       },
-      "parent_id": null
+      "parent_id": "Q1168"
     },
     {
       "id": "Q2738086",
@@ -11884,7 +12609,7 @@
         "lang:hi": "उस्मानाबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Osmanabad"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q2738103",
@@ -11909,7 +12634,7 @@
         "lang:hi": "अहमदनगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ahmednagar"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q279102",
@@ -11934,7 +12659,7 @@
         "lang:hi": "खरगोन लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Khargone"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q2912408",
@@ -11959,7 +12684,7 @@
         "lang:hi": "चन्द्रपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chandrapur"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q2912894",
@@ -11984,7 +12709,7 @@
         "lang:hi": "हिंगोली लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Hingoli"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q3348171",
@@ -12009,7 +12734,7 @@
         "lang:hi": "कोलकाता दक्षिण लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kolkata Dakshin"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q3348198",
@@ -12034,7 +12759,7 @@
         "lang:hi": "जलपाईगुड़ी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jalpaiguri"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q3348210",
@@ -12059,7 +12784,7 @@
         "lang:hi": "उलूबेरिया लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Uluberia"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q3348243",
@@ -12084,7 +12809,7 @@
         "lang:hi": "हावड़ा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Howrah"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q3351410",
@@ -12109,7 +12834,7 @@
         "lang:hi": "कांथी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kanthi"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q3351420",
@@ -12134,7 +12859,7 @@
         "lang:hi": "कूचबिहार लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Cooch Behar"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q3351485",
@@ -12159,7 +12884,7 @@
         "lang:hi": "तामलुक लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Tamluk"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q3521014",
@@ -12184,7 +12909,7 @@
         "lang:hi": "बेल्लारी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bellary"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q3530684",
@@ -12209,7 +12934,7 @@
         "lang:hi": "अण्डमान और निकोबार द्वीपसमूह लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Andaman and Nicobar Islands"
       },
-      "parent_id": null
+      "parent_id": "Q40888"
     },
     {
       "id": "Q3532420",
@@ -12234,7 +12959,7 @@
         "lang:hi": "तिरुचिरापल्ली लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Tiruchirappalli"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3532431",
@@ -12259,7 +12984,7 @@
         "lang:hi": "चेन्नई दक्षिण लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chennai South"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3532436",
@@ -12284,7 +13009,7 @@
         "lang:hi": "धर्मपुरी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dharmapuri"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3532474",
@@ -12309,7 +13034,7 @@
         "lang:hi": "चेन्नई मध्य लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chennai Central"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3532480",
@@ -12334,7 +13059,7 @@
         "lang:hi": "करूर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Karur"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3532492",
@@ -12359,7 +13084,7 @@
         "lang:hi": "रामनाथपुरम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ramanathapuram"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3532545",
@@ -12384,7 +13109,7 @@
         "lang:hi": "चेन्नई उत्तर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chennai North"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3532551",
@@ -12409,7 +13134,7 @@
         "lang:hi": "विलुपुरम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Viluppuram"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3532557",
@@ -12434,7 +13159,7 @@
         "lang:hi": "पुदुच्चेरी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Puducherry"
       },
-      "parent_id": null
+      "parent_id": "Q66743"
     },
     {
       "id": "Q3532565",
@@ -12459,7 +13184,7 @@
         "lang:hi": "डिंडीगुल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dindigul"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3532569",
@@ -12484,7 +13209,7 @@
         "lang:hi": "सेलम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Salem"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3532578",
@@ -12509,7 +13234,7 @@
         "lang:hi": "तेनकासी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Tenkasi"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3533589",
@@ -12534,7 +13259,7 @@
         "lang:hi": "अरानी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Arani"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3533967",
@@ -12559,7 +13284,7 @@
         "lang:hi": "नागापट्टिनम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nagapattinam"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3533974",
@@ -12584,7 +13309,7 @@
         "lang:hi": "चिदंबरम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chidambaram"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3533981",
@@ -12609,7 +13334,7 @@
         "lang:hi": "तिरुनेलवेली लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Tirunelveli"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3534013",
@@ -12634,7 +13359,7 @@
         "lang:hi": "मदुरै लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Madurai"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3534043",
@@ -12659,7 +13384,7 @@
         "lang:hi": "कृष्णागिरि लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Krishnagiri"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3534088",
@@ -12684,7 +13409,7 @@
         "lang:hi": "अर्कोनम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Arakkonam"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3534098",
@@ -12709,7 +13434,7 @@
         "lang:hi": "वेल्लौर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Vellore"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3534106",
@@ -12734,7 +13459,7 @@
         "lang:hi": "मयिलादुतुरई लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mayiladuturai"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3534118",
@@ -12759,7 +13484,7 @@
         "lang:hi": "कोयम्बटूर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Coimbatore"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3534127",
@@ -12784,7 +13509,7 @@
         "lang:hi": "विरुधुनगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Virudhunagar"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3534136",
@@ -12809,7 +13534,7 @@
         "lang:hi": "शिवगंगा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sivaganga"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3534177",
@@ -12834,7 +13559,7 @@
         "lang:hi": "नीलगिरि लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nilgiris"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3534197",
@@ -12859,7 +13584,7 @@
         "lang:hi": "श्रीपेरूम्बुदूर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sriperumbudur"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3534206",
@@ -12884,7 +13609,7 @@
         "lang:hi": "थूथुक्कुडी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Thoothukudi"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3534214",
@@ -12909,7 +13634,7 @@
         "lang:hi": "पैरम्बलूर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Perambalur"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3534217",
@@ -12934,7 +13659,7 @@
         "lang:hi": "पोल्लाची लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Pollachi"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3534221",
@@ -12959,7 +13684,7 @@
         "lang:hi": "कुड्डालोर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Cuddalore"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3534230",
@@ -12984,7 +13709,7 @@
         "lang:hi": "तंजावूर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Thanjavur"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q3595199",
@@ -13009,7 +13734,7 @@
         "lang:hi": "त्रिस्सूर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Thrissur"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q3595235",
@@ -13034,7 +13759,7 @@
         "lang:hi": "पोन्नानी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ponnani"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q3595239",
@@ -13059,7 +13784,7 @@
         "lang:hi": "कोष़िक्कोड लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kozhikode"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q3595248",
@@ -13084,7 +13809,7 @@
         "lang:hi": "चालाकुडी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chalakudy"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q3595257",
@@ -13109,7 +13834,7 @@
         "lang:hi": "कासरगोड लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kasaragod"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q3595261",
@@ -13134,7 +13859,7 @@
         "lang:hi": "कन्नूर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kannur"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q3595264",
@@ -13159,7 +13884,7 @@
         "lang:hi": "वडकरा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Vadakara"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q3595286",
@@ -13184,7 +13909,7 @@
         "lang:hi": "कोल्लम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kollam"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q3595483",
@@ -13209,7 +13934,7 @@
         "lang:hi": "मवेलीकारा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mavelikara"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q3595497",
@@ -13234,7 +13959,7 @@
         "lang:hi": "एर्णाकुलम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ernakulam"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q3595503",
@@ -13259,7 +13984,7 @@
         "lang:hi": "इदुक्की लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Idukki"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q3595510",
@@ -13284,7 +14009,7 @@
         "lang:hi": "अलप्पुझा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Alappuzha"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q3595511",
@@ -13309,7 +14034,7 @@
         "lang:hi": "पलक्काड लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Palakkad"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q3595519",
@@ -13334,7 +14059,7 @@
         "lang:hi": "कोट्टायम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kottayam"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q3630009",
@@ -13359,7 +14084,7 @@
         "lang:hi": "नगर कुरनूल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nagarkurnool"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     },
     {
       "id": "Q3630014",
@@ -13384,7 +14109,7 @@
         "lang:hi": "अदीलाबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Adilabad"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     },
     {
       "id": "Q3630032",
@@ -13409,7 +14134,7 @@
         "lang:hi": "बापतला लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bapatla"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3630204",
@@ -13434,7 +14159,7 @@
         "lang:hi": "अमलापुरम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Amalapuram"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3630208",
@@ -13458,7 +14183,7 @@
       "name": {
         "lang:en": "Mahabubnagar"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     },
     {
       "id": "Q3630236",
@@ -13483,7 +14208,7 @@
         "lang:hi": "अनकापल्ली लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Anakapalli"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3630239",
@@ -13508,7 +14233,7 @@
         "lang:hi": "अनन्तपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Anantapuramu"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3630669",
@@ -13533,7 +14258,7 @@
         "lang:hi": "मुजफ्फरनगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Muzaffarnagar"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3630705",
@@ -13558,7 +14283,7 @@
         "lang:hi": "वाराणसी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Varanasi"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3630725",
@@ -13583,7 +14308,7 @@
         "lang:hi": "उज्जैन लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ujjain"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q3630763",
@@ -13608,7 +14333,7 @@
         "lang:hi": "मण्डला लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mandla"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q3630783",
@@ -13633,7 +14358,7 @@
         "lang:hi": "सीतापुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sitapur"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3632253",
@@ -13658,7 +14383,7 @@
         "lang:hi": "राजगढ़ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Rajgarh"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q3632303",
@@ -13683,7 +14408,7 @@
         "lang:hi": "सिंहभूम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Singhbhum"
       },
-      "parent_id": null
+      "parent_id": "Q1184"
     },
     {
       "id": "Q3632585",
@@ -13708,7 +14433,7 @@
         "lang:hi": "हजारीबाग लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Hazaribagh"
       },
-      "parent_id": null
+      "parent_id": "Q1184"
     },
     {
       "id": "Q3632592",
@@ -13733,7 +14458,7 @@
         "lang:hi": "अल्मोड़ा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Almora"
       },
-      "parent_id": null
+      "parent_id": "Q1499"
     },
     {
       "id": "Q3632604",
@@ -13758,7 +14483,7 @@
         "lang:hi": "आरा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Arrah"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q3632618",
@@ -13783,7 +14508,7 @@
         "lang:hi": "गढ़वाल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Garhwal"
       },
-      "parent_id": null
+      "parent_id": "Q1499"
     },
     {
       "id": "Q3632662",
@@ -13808,7 +14533,7 @@
         "lang:hi": "दुर्ग लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Durg"
       },
-      "parent_id": null
+      "parent_id": "Q1168"
     },
     {
       "id": "Q3632686",
@@ -13833,7 +14558,7 @@
         "lang:hi": "पलामू लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Palamu"
       },
-      "parent_id": null
+      "parent_id": "Q1184"
     },
     {
       "id": "Q3632704",
@@ -13858,7 +14583,7 @@
         "lang:hi": "मधुबनी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Madhubani"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q3632717",
@@ -13883,7 +14608,7 @@
         "lang:hi": "अररिया लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Araria"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q3633068",
@@ -13908,7 +14633,7 @@
         "lang:hi": "अराकु लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Araku"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3633148",
@@ -13933,7 +14658,7 @@
         "lang:hi": "हाजीपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Hajipur"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q3633170",
@@ -13958,7 +14683,7 @@
         "lang:hi": "गया लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Gaya"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q3633217",
@@ -13983,7 +14708,7 @@
         "lang:hi": "गोपालगंज लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Gopalganj"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q3633242",
@@ -14008,7 +14733,7 @@
         "lang:hi": "मुंगेर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Munger"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q3633257",
@@ -14033,7 +14758,7 @@
         "lang:hi": "भागलपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bhagalpur"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q3633289",
@@ -14058,7 +14783,7 @@
         "lang:hi": "कटिहार लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Katihar"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q3633305",
@@ -14083,7 +14808,7 @@
         "lang:hi": "मुजफ्फरपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Muzaffarpur"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q3633316",
@@ -14108,7 +14833,7 @@
         "lang:hi": "अकबरपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Akbarpur"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3633321",
@@ -14133,7 +14858,7 @@
         "lang:hi": "नवादा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nawada"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q3633352",
@@ -14158,7 +14883,7 @@
         "lang:hi": "बागपत लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Baghpat"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3633377",
@@ -14183,7 +14908,7 @@
         "lang:hi": "सासाराम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sasaram"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q3633391",
@@ -14208,7 +14933,7 @@
         "lang:hi": "बिजनौर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bijnor"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3633418",
@@ -14233,7 +14958,7 @@
         "lang:hi": "अमरोहा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Amroha"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3633423",
@@ -14258,7 +14983,7 @@
         "lang:hi": "पूर्णिया लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Purnia"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q3633461",
@@ -14283,7 +15008,7 @@
         "lang:hi": "बाराबंकी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Barabanki"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3633465",
@@ -14308,7 +15033,7 @@
         "lang:hi": "बालाघाट लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Balaghat"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q3634165",
@@ -14333,7 +15058,7 @@
         "lang:hi": "ग्वालियर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Gwalior"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q3634168",
@@ -14358,7 +15083,7 @@
         "lang:hi": "गुना लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Guna"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q3634171",
@@ -14383,7 +15108,7 @@
         "lang:hi": "झांसी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jhansi"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3634176",
@@ -14408,7 +15133,7 @@
         "lang:hi": "देवरिया लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Deoria"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3634185",
@@ -14433,7 +15158,7 @@
         "lang:hi": "धार लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dhar"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q3634190",
@@ -14458,7 +15183,7 @@
         "lang:hi": "बुलन्दशहर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bulandshahr"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3634194",
@@ -14483,7 +15208,7 @@
         "lang:hi": "इन्दौर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Indore"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q3634204",
@@ -14508,7 +15233,7 @@
         "lang:hi": "कैसरगंज लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kaiserganj"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3634216",
@@ -14533,7 +15258,7 @@
         "lang:hi": "खंडवा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Khandwa"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q3634234",
@@ -14558,7 +15283,7 @@
         "lang:hi": "मथुरा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mathura"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3634240",
@@ -14583,7 +15308,7 @@
         "lang:hi": "होशंगाबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Hoshangabad"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q3634246",
@@ -14608,7 +15333,7 @@
         "lang:hi": "भिण्ड लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bhind"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q3634262",
@@ -14633,7 +15358,7 @@
         "lang:hi": "एटा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Etah"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3634359",
@@ -14658,7 +15383,7 @@
         "lang:hi": "खजुराहो लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Khajuraho"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q3635773",
@@ -14683,7 +15408,7 @@
         "lang:hi": "मुरादाबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Moradabad"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3663904",
@@ -14708,7 +15433,7 @@
         "lang:hi": "मुरैना लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Morena"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q371869",
@@ -14733,7 +15458,7 @@
         "lang:hi": "अलीगढ़ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Aligarh"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3763762",
@@ -14758,7 +15483,7 @@
         "lang:hi": "शिरडी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Shirdi"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q3763786",
@@ -14783,7 +15508,7 @@
         "lang:hi": "औरंगाबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Aurangabad"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q3763828",
@@ -14808,7 +15533,7 @@
         "lang:hi": "परभनी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Parbhani"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q3763840",
@@ -14833,7 +15558,7 @@
         "lang:hi": "कुरनूल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kurnool"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3763879",
@@ -14858,7 +15583,7 @@
         "lang:hi": "नरसापुरम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Narsapuram"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3763885",
@@ -14883,7 +15608,7 @@
         "lang:hi": "चित्तूर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chittoor"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3763891",
@@ -14908,7 +15633,7 @@
         "lang:hi": "सतारा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Satara"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q3763938",
@@ -14933,7 +15658,7 @@
         "lang:hi": "वारंगल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Warangal"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     },
     {
       "id": "Q3763943",
@@ -14958,7 +15683,7 @@
         "lang:hi": "कल्याण लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kalyan"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q3763969",
@@ -14983,7 +15708,7 @@
         "lang:hi": "नालगौंडा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nalgonda"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     },
     {
       "id": "Q3763974",
@@ -15008,7 +15733,7 @@
         "lang:hi": "विशाखापत्तनम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Visakhapatnam"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3764021",
@@ -15033,7 +15758,7 @@
         "lang:hi": "नांदेड़ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nanded"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q3764026",
@@ -15058,7 +15783,7 @@
         "lang:hi": "ओंगोले लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ongole"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3764036",
@@ -15083,7 +15808,7 @@
         "lang:hi": "मेडक लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Medak"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     },
     {
       "id": "Q3764050",
@@ -15108,7 +15833,7 @@
         "lang:hi": "काकीनाड़ा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kakinada"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3764062",
@@ -15133,7 +15858,7 @@
         "lang:hi": "एलूरू लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Eluru"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3764091",
@@ -15158,7 +15883,7 @@
         "lang:hi": "खम्माम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Khammam"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     },
     {
       "id": "Q3764307",
@@ -15183,7 +15908,7 @@
         "lang:hi": "हैदराबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Hyderabad"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     },
     {
       "id": "Q3764327",
@@ -15208,7 +15933,7 @@
         "lang:hi": "सिकन्दराबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Secunderabad"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     },
     {
       "id": "Q3764335",
@@ -15233,7 +15958,7 @@
         "lang:hi": "निजामाबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nizamabad"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     },
     {
       "id": "Q3764342",
@@ -15258,7 +15983,7 @@
         "lang:hi": "राजामुन्दरी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Rajahmundry"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3764353",
@@ -15283,7 +16008,7 @@
         "lang:hi": "करीमनगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Karimnagar"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     },
     {
       "id": "Q3764361",
@@ -15308,7 +16033,7 @@
         "lang:hi": "रामटेक लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ramtek"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q3764367",
@@ -15333,7 +16058,7 @@
         "lang:hi": "नांदयाल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nandyal"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3764387",
@@ -15358,7 +16083,7 @@
         "lang:hi": "बनासकांठा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Banaskantha"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q3764391",
@@ -15383,7 +16108,7 @@
         "lang:hi": "अकोला (लोक सभा निर्वाचन क्षेत्र)",
         "lang:en": "Akola (Lok Sabha Constituency)"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q3764398",
@@ -15408,7 +16133,7 @@
         "lang:hi": "बारामती लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Baramati"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q3764405",
@@ -15433,7 +16158,7 @@
         "lang:hi": "कडापा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kadapa"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3764410",
@@ -15458,7 +16183,7 @@
         "lang:hi": "गुंटूर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Guntur"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3764429",
@@ -15483,7 +16208,7 @@
         "lang:hi": "हिन्दुपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Hindupur"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3764433",
@@ -15508,7 +16233,7 @@
         "lang:hi": "भन्डारा गोंदिया लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bhandara-Gondiya"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q3764439",
@@ -15533,7 +16258,7 @@
         "lang:hi": "शोलापुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Solapur"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q3764443",
@@ -15558,7 +16283,7 @@
         "lang:hi": "नरसारावपेट लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Narasaraopet"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3764455",
@@ -15583,7 +16308,7 @@
         "lang:hi": "नागपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nagpur"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q3764461",
@@ -15608,7 +16333,7 @@
         "lang:hi": "लातूर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Latur"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q3764468",
@@ -15633,7 +16358,7 @@
         "lang:hi": "अहमदाबाद पश्चिम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ahmedabad West"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q3764476",
@@ -15658,7 +16383,7 @@
         "lang:hi": "राजमपेट",
         "lang:en": "Rajampet"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3764479",
@@ -15683,7 +16408,7 @@
         "lang:hi": "वर्धा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Wardha"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q3764487",
@@ -15708,7 +16433,7 @@
         "lang:hi": "श्रीकाकुलम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Srikakulam"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3764491",
@@ -15733,7 +16458,7 @@
         "lang:hi": "अमरावती लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Amravati"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q3764496",
@@ -15758,7 +16483,7 @@
         "lang:hi": "पेड्डापल्ले लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Peddapalli"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     },
     {
       "id": "Q3764509",
@@ -15783,7 +16508,7 @@
         "lang:hi": "नेल्लौर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nellore"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3764514",
@@ -15808,7 +16533,7 @@
         "lang:hi": "तिरुपति लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Tirupati"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3765227",
@@ -15833,7 +16558,7 @@
         "lang:hi": "अमरेली लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Amreli"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q3765236",
@@ -15858,7 +16583,7 @@
         "lang:hi": "विजयवाड़ा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Vijayawada"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3765244",
@@ -15883,7 +16608,7 @@
         "lang:hi": "मछलीपत्तनम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Machilipatnam"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q3823603",
@@ -15908,7 +16633,7 @@
         "lang:hi": "मोहनलाल गंज लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mohanlalganj"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q3883318",
@@ -15933,7 +16658,7 @@
         "lang:hi": "बीदर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bidar"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q3939251",
@@ -15958,7 +16683,7 @@
         "lang:hi": "चिक्कोडी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chikkodi"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q3995921",
@@ -15983,7 +16708,32 @@
         "lang:hi": "बेलगाम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Belagavi"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
+    },
+    {
+      "id": "Q40888",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/territory:an"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q40888"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "union territory of India",
+        "lang:hi": "भारत के संघ राज्यक्षेत्र"
+      },
+      "name": {
+        "lang:hi": "अण्डमान और निकोबार द्वीपसमूह",
+        "lang:en": "Andaman and Nicobar Islands"
+      },
+      "parent_id": "Q668"
     },
     {
       "id": "Q4172532",
@@ -16008,7 +16758,7 @@
         "lang:hi": "गुलबर्गा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Gulbarga"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q4172533",
@@ -16033,7 +16783,7 @@
         "lang:hi": "रायचूर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Raichur"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q4252512",
@@ -16058,7 +16808,7 @@
         "lang:hi": "लद्दाख लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ladakh"
       },
-      "parent_id": null
+      "parent_id": "Q1180"
     },
     {
       "id": "Q4348317",
@@ -16083,7 +16833,7 @@
         "lang:hi": "कोप्पल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Koppal"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q4628043",
@@ -16108,7 +16858,7 @@
         "lang:hi": "कावेरी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Haveri"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q4693670",
@@ -16133,7 +16883,7 @@
         "lang:hi": "आगरा लोकसभा निर्वाचन क्षेत्र",
         "lang:en": "Agra"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q4696121",
@@ -16158,7 +16908,7 @@
         "lang:hi": "अहमदाबाद पूर्व लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ahmedabad East"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q4699904",
@@ -16183,7 +16933,7 @@
         "lang:hi": "अजमेर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ajmer"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q4708818",
@@ -16208,7 +16958,7 @@
         "lang:hi": "अलथूर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Alathur"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q4726846",
@@ -16233,7 +16983,7 @@
         "lang:hi": "अलीपुरद्वार लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Alipurduars"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q4730342",
@@ -16258,7 +17008,7 @@
         "lang:hi": "इलाहाबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Allahabad"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q4738368",
@@ -16283,7 +17033,7 @@
         "lang:hi": "अलवर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Alwar"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q4740955",
@@ -16308,7 +17058,7 @@
         "lang:hi": "अम्बाला लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ambala"
       },
-      "parent_id": null
+      "parent_id": "Q1174"
     },
     {
       "id": "Q4741186",
@@ -16333,7 +17083,7 @@
         "lang:hi": "अम्बेडकर नगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ambedkar Nagar"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q4745924",
@@ -16358,7 +17108,7 @@
         "lang:hi": "अमेठी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Amethi"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q4748702",
@@ -16383,7 +17133,7 @@
         "lang:hi": "अमृतसर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Amritsar"
       },
-      "parent_id": null
+      "parent_id": "Q22424"
     },
     {
       "id": "Q4751232",
@@ -16408,7 +17158,7 @@
         "lang:hi": "आनन्द लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Anand"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q4751375",
@@ -16433,7 +17183,7 @@
         "lang:hi": "आनंदपुर साहिब लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Anandpur Sahib"
       },
-      "parent_id": null
+      "parent_id": "Q22424"
     },
     {
       "id": "Q4751497",
@@ -16458,7 +17208,7 @@
         "lang:hi": "अनंतनाग लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Anantnag"
       },
-      "parent_id": null
+      "parent_id": "Q1180"
     },
     {
       "id": "Q4756549",
@@ -16483,7 +17233,7 @@
         "lang:hi": "उत्तर कन्नड़ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Uttara Kannada"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q4778703",
@@ -16508,7 +17258,7 @@
         "lang:hi": "आंवला लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Aonla"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q4783993",
@@ -16533,7 +17283,7 @@
         "lang:hi": "आरामबाग लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Arambagh"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q4803541",
@@ -16558,7 +17308,7 @@
         "lang:hi": "आसनसोल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Asansol"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q4807113",
@@ -16583,7 +17333,7 @@
         "lang:hi": "आस्का लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Aska"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q4822111",
@@ -16608,7 +17358,7 @@
         "lang:hi": "औरंगाबाद (बिहार) लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Aurangabad (Bihar)"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q4841427",
@@ -16633,7 +17383,7 @@
         "lang:hi": "बागलकोट लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bagalkot"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q4842446",
@@ -16658,7 +17408,7 @@
         "lang:hi": "बहरामपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Baharampur"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q4842725",
@@ -16683,7 +17433,7 @@
         "lang:hi": "बहराइच लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bahraich"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q4850118",
@@ -16708,7 +17458,7 @@
         "lang:hi": "बालासोर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Balasore"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q4851665",
@@ -16733,7 +17483,7 @@
         "lang:hi": "बलिया लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ballia"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q4853085",
@@ -16758,7 +17508,7 @@
         "lang:hi": "बलूरघाट लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Balurghat"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q4855038",
@@ -16783,7 +17533,7 @@
         "lang:hi": "बंगलौर केन्द्रीय लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bangalore Central"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q4855069",
@@ -16808,7 +17558,7 @@
         "lang:hi": "बंगलौर उत्तर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bangalore North"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q4855074",
@@ -16833,7 +17583,7 @@
         "lang:hi": "बंगलौर ग्रामीण लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bangalore Rural Lok Sabha constituency"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q4855093",
@@ -16858,7 +17608,7 @@
         "lang:hi": "बनगाँव लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bangaon"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q4856235",
@@ -16883,7 +17633,7 @@
         "lang:hi": "बांका लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Banka"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q4856799",
@@ -16908,7 +17658,7 @@
         "lang:hi": "बांकुरा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bankura"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q4857123",
@@ -16933,7 +17683,7 @@
         "lang:hi": "बांसगांव लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bansgaon"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q4857164",
@@ -16958,7 +17708,7 @@
         "lang:hi": "बांसवाड़ा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Banswara"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q4858316",
@@ -16983,7 +17733,7 @@
         "lang:hi": "बारामूला लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Baramulla"
       },
-      "parent_id": null
+      "parent_id": "Q1180"
     },
     {
       "id": "Q4858448",
@@ -17008,7 +17758,7 @@
         "lang:hi": "बारासाट लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Barasat"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q4860137",
@@ -17033,7 +17783,7 @@
         "lang:hi": "बर्धमान-दुर्गापुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bardhaman-Durgapur"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q4860138",
@@ -17058,7 +17808,7 @@
         "lang:hi": "बर्धमान-पूर्बा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bardhaman Purba"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q4860193",
@@ -17083,7 +17833,7 @@
         "lang:hi": "बारडोली लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bardoli"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q4860392",
@@ -17108,7 +17858,7 @@
         "lang:hi": "बरेली लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bareilly"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q4860546",
@@ -17133,7 +17883,7 @@
         "lang:hi": "बरगढ़ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bargarh"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q4861268",
@@ -17158,7 +17908,7 @@
         "lang:hi": "बाड़मेर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Barmer"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q4863171",
@@ -17183,7 +17933,7 @@
         "lang:hi": "बैरकपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Barrackpore"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q4867561",
@@ -17208,7 +17958,7 @@
         "lang:hi": "बसीरहाट लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Basirhat"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q4868222",
@@ -17233,7 +17983,7 @@
         "lang:hi": "बस्तर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bastar"
       },
-      "parent_id": null
+      "parent_id": "Q1168"
     },
     {
       "id": "Q4868265",
@@ -17258,7 +18008,7 @@
         "lang:hi": "बस्ती लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Basti"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q4869032",
@@ -17283,7 +18033,7 @@
         "lang:hi": "भटिंडा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bathinda"
       },
-      "parent_id": null
+      "parent_id": "Q22424"
     },
     {
       "id": "Q4876992",
@@ -17308,7 +18058,7 @@
         "lang:hi": "शिमोगा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Shimoga"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q4877000",
@@ -17333,7 +18083,7 @@
         "lang:hi": "दावणगेरे लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Davangere"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q4879723",
@@ -17358,7 +18108,7 @@
         "lang:hi": "बीड लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Beed"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q4880639",
@@ -17383,7 +18133,7 @@
         "lang:hi": "बेगूसराय लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Begusarai"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q4899044",
@@ -17408,7 +18158,7 @@
         "lang:hi": "बेतूल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Betul"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q4900529",
@@ -17433,7 +18183,7 @@
         "lang:hi": "भदोही लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bhadohi"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q4900550",
@@ -17458,7 +18208,7 @@
         "lang:hi": "भद्रक लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bhadrak"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q4901252",
@@ -17483,7 +18233,7 @@
         "lang:hi": "भरतपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bharatpur"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q4901329",
@@ -17508,7 +18258,7 @@
         "lang:hi": "भरूच लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bharuch"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q4901564",
@@ -17533,7 +18283,7 @@
         "lang:hi": "भावनगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bhavnagar"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q4901736",
@@ -17558,7 +18308,7 @@
         "lang:hi": "भीलवाड़ा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bhilwara"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q4901856",
@@ -17583,7 +18333,7 @@
         "lang:hi": "भिवानी महेन्द्रगढ़ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bhiwani-Mahendragarh"
       },
-      "parent_id": null
+      "parent_id": "Q1174"
     },
     {
       "id": "Q4901857",
@@ -17608,7 +18358,7 @@
         "lang:hi": "भिवंडी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bhiwandi"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q4901952",
@@ -17633,7 +18383,7 @@
         "lang:hi": "भोंगीर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bhuvanagiri"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     },
     {
       "id": "Q4901994",
@@ -17658,7 +18408,7 @@
         "lang:hi": "भोपाल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bhopal"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q4902092",
@@ -17683,7 +18433,7 @@
         "lang:hi": "भुवनेश्वर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bhubaneswar"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q4907176",
@@ -17708,7 +18458,7 @@
         "lang:hi": "बीजापुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bijapur"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q4907311",
@@ -17733,7 +18483,7 @@
         "lang:hi": "बीकानेर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bikaner"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q4907564",
@@ -17758,7 +18508,7 @@
         "lang:hi": "बिलासपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bilaspur"
       },
-      "parent_id": null
+      "parent_id": "Q1168"
     },
     {
       "id": "Q4915625",
@@ -17783,7 +18533,7 @@
         "lang:hi": "बीरभूम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Birbhum"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q4917381",
@@ -17808,7 +18558,7 @@
         "lang:hi": "विष्णुपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bishnupur"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q4938935",
@@ -17833,7 +18583,7 @@
         "lang:hi": "बलांगिर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bolangir"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q4940018",
@@ -17858,7 +18608,7 @@
         "lang:hi": "बोलपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bolpur"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q4996106",
@@ -17883,7 +18633,7 @@
         "lang:hi": "बुलढाना लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Buldhana"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q4998317",
@@ -17907,7 +18657,7 @@
       "name": {
         "lang:en": "Burdwan"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5003234",
@@ -17932,7 +18682,7 @@
         "lang:hi": "बक्सर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Buxar"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q5069470",
@@ -17957,7 +18707,7 @@
         "lang:hi": "चामराजनगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chamarajanagar"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q5070983",
@@ -17982,7 +18732,7 @@
         "lang:hi": "चन्दौली लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chandauli"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5071061",
@@ -18031,7 +18781,7 @@
         "lang:hi": "चाँदनी चौक लोकसभा निर्वाचन क्षेत्र",
         "lang:en": "Chandni Chowk"
       },
-      "parent_id": null
+      "parent_id": "Q1353"
     },
     {
       "id": "Q5087772",
@@ -18056,7 +18806,7 @@
         "lang:hi": "चतरा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chatra"
       },
-      "parent_id": null
+      "parent_id": "Q1184"
     },
     {
       "id": "Q5094314",
@@ -18081,7 +18831,7 @@
         "lang:hi": "चेवेल्ला लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chevella"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     },
     {
       "id": "Q5094902",
@@ -18106,7 +18856,7 @@
         "lang:hi": "छिंदवाड़ा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chhindwara"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q5094957",
@@ -18131,7 +18881,7 @@
         "lang:hi": "छोटा उदयपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chhota Udaipur"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q5097405",
@@ -18156,7 +18906,7 @@
         "lang:hi": "चिकबलपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chikballapur"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q5102316",
@@ -18181,7 +18931,7 @@
         "lang:hi": "चित्रदुर्ग लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chitradurga"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q5102518",
@@ -18206,7 +18956,7 @@
         "lang:hi": "चित्तौड़गढ़ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Chittorgarh"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q5118333",
@@ -18231,7 +18981,7 @@
         "lang:hi": "चूरू लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Churu"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q5121423",
@@ -18256,7 +19006,7 @@
         "lang:hi": "दक्षिण कन्नड लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dakshina Kannada"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q5187868",
@@ -18281,7 +19031,7 @@
         "lang:hi": "मांडया लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mandya"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q5196922",
@@ -18306,7 +19056,7 @@
         "lang:hi": "कटक लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Cuttack"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q5208111",
@@ -18356,7 +19106,7 @@
         "lang:hi": "दोहद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dahod"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q5211945",
@@ -18406,7 +19156,7 @@
         "lang:hi": "दरभंगा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Darbhanga"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q5223069",
@@ -18431,7 +19181,7 @@
         "lang:hi": "दार्जिलिंग लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Darjeeling"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q5228102",
@@ -18456,7 +19206,7 @@
         "lang:hi": "दौसा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dausa"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q5245318",
@@ -18481,7 +19231,7 @@
         "lang:hi": "तुमकुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Tumkur"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q5268930",
@@ -18506,7 +19256,7 @@
         "lang:hi": "धनबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dhanbad"
       },
-      "parent_id": null
+      "parent_id": "Q1184"
     },
     {
       "id": "Q5269410",
@@ -18531,7 +19281,7 @@
         "lang:hi": "धारवाड़ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dharwad"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q5269512",
@@ -18556,7 +19306,7 @@
         "lang:hi": "ढेंकानाल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dhenkanal"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q5269854",
@@ -18581,7 +19331,7 @@
         "lang:hi": "धुले लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dhule"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q5270807",
@@ -18606,7 +19356,7 @@
         "lang:hi": "डायमंड हार्बर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Diamond Harbour"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q5278011",
@@ -18631,7 +19381,7 @@
         "lang:hi": "दिन्डोरी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dindori"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q5289934",
@@ -18656,7 +19406,7 @@
         "lang:hi": "डुमरियागंज लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Domariyaganj"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5313570",
@@ -18681,7 +19431,7 @@
         "lang:hi": "दमदम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dum Dum"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q5313895",
@@ -18706,7 +19456,7 @@
         "lang:hi": "दुमका लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Dumka"
       },
-      "parent_id": null
+      "parent_id": "Q1184"
     },
     {
       "id": "Q5328213",
@@ -18731,7 +19481,7 @@
         "lang:hi": "पूर्वी दिल्ली लोकसभा निर्वाचन क्षेत्र",
         "lang:en": "East Delhi"
       },
-      "parent_id": null
+      "parent_id": "Q1353"
     },
     {
       "id": "Q5332086",
@@ -18756,7 +19506,7 @@
         "lang:hi": "मैसूर",
         "lang:en": "Mysore"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q5395251",
@@ -18781,7 +19531,7 @@
         "lang:hi": "इरोड लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Erode"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q5402455",
@@ -18806,7 +19556,7 @@
         "lang:hi": "इटावा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Etawah"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5431351",
@@ -18831,7 +19581,7 @@
         "lang:hi": "फैजाबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Faizabad"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5435282",
@@ -18856,7 +19606,7 @@
         "lang:hi": "फरीदाबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Faridabad"
       },
-      "parent_id": null
+      "parent_id": "Q1174"
     },
     {
       "id": "Q5435297",
@@ -18881,7 +19631,7 @@
         "lang:hi": "फरीदकोट लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Faridkot"
       },
-      "parent_id": null
+      "parent_id": "Q22424"
     },
     {
       "id": "Q5436365",
@@ -18906,7 +19656,7 @@
         "lang:hi": "फरुखाबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Farrukhabad"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5437417",
@@ -18931,7 +19681,7 @@
         "lang:hi": "फतेहगढ़ साहिब लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Fatehgarh Sahib"
       },
-      "parent_id": null
+      "parent_id": "Q22424"
     },
     {
       "id": "Q5437428",
@@ -18956,7 +19706,7 @@
         "lang:hi": "फतेहपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Fatehpur"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5437430",
@@ -18981,7 +19731,7 @@
         "lang:hi": "फतेहपुर सीकरी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Fatehpur Sikri"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5452174",
@@ -19006,7 +19756,7 @@
         "lang:hi": "फिरोजाबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Firozabad"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5452175",
@@ -19031,7 +19781,7 @@
         "lang:hi": "फिरोजपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Firozepur"
       },
-      "parent_id": null
+      "parent_id": "Q22424"
     },
     {
       "id": "Q5520735",
@@ -19056,7 +19806,7 @@
         "lang:hi": "गांधीनगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Gandhinagar"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q5521052",
@@ -19081,7 +19831,7 @@
         "lang:hi": "श्रीगंगानगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ganganagar"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q5527870",
@@ -19106,7 +19856,7 @@
         "lang:hi": "गौतम बुद्ध नगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Gautam Buddha Nagar"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5555886",
@@ -19131,7 +19881,7 @@
         "lang:hi": "घाटल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ghatal"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q5556091",
@@ -19156,7 +19906,7 @@
         "lang:hi": "गाज़ियाबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ghaziabad"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5556103",
@@ -19181,7 +19931,7 @@
         "lang:hi": "गाजीपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ghazipur"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5557002",
@@ -19206,7 +19956,7 @@
         "lang:hi": "घोसी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ghosi"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5564263",
@@ -19231,7 +19981,7 @@
         "lang:hi": "गिरिडीह लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Giridih"
       },
-      "parent_id": null
+      "parent_id": "Q1184"
     },
     {
       "id": "Q5576233",
@@ -19256,7 +20006,7 @@
         "lang:hi": "गोड्डा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Godda"
       },
-      "parent_id": null
+      "parent_id": "Q1184"
     },
     {
       "id": "Q5584396",
@@ -19281,7 +20031,7 @@
         "lang:hi": "गोरखपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Gorakhpur"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5619909",
@@ -19306,7 +20056,7 @@
         "lang:hi": "गुरदासपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Gurdaspur"
       },
-      "parent_id": null
+      "parent_id": "Q22424"
     },
     {
       "id": "Q5620004",
@@ -19331,7 +20081,7 @@
         "lang:hi": "गुड़गांव लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Gurgaon"
       },
-      "parent_id": null
+      "parent_id": "Q1174"
     },
     {
       "id": "Q5645332",
@@ -19356,7 +20106,7 @@
         "lang:hi": "हमीरपुर (उत्तर प्रदेश) लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Hamirpur"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5645333",
@@ -19381,7 +20131,7 @@
         "lang:hi": "हमीरपुर (उत्तर प्रदेश) लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Hamirpur"
       },
-      "parent_id": null
+      "parent_id": "Q1177"
     },
     {
       "id": "Q5656282",
@@ -19406,7 +20156,7 @@
         "lang:hi": "हरदोई लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Hardoi"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5657364",
@@ -19431,7 +20181,7 @@
         "lang:hi": "हरिद्वार लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Haridwar"
       },
-      "parent_id": null
+      "parent_id": "Q1499"
     },
     {
       "id": "Q5679532",
@@ -19456,7 +20206,7 @@
         "lang:hi": "हसन लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Haasan"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q5681557",
@@ -19481,7 +20231,7 @@
         "lang:hi": "हाथरस लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Hathras"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q5908015",
@@ -19506,7 +20256,7 @@
         "lang:hi": "होशियारपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Hoshiarpur"
       },
-      "parent_id": null
+      "parent_id": "Q22424"
     },
     {
       "id": "Q6035471",
@@ -19531,7 +20281,7 @@
         "lang:hi": "आंतरिक मणिपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Inner Manipur"
       },
-      "parent_id": null
+      "parent_id": "Q1193"
     },
     {
       "id": "Q6109952",
@@ -19556,7 +20306,7 @@
         "lang:hi": "जबलपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jabalpur"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q6122268",
@@ -19581,7 +20331,7 @@
         "lang:hi": "जगतसिंहपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jagatsinghpur"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q6124117",
@@ -19606,7 +20356,7 @@
         "lang:hi": "जयपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jaipur"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q6124137",
@@ -19631,7 +20381,7 @@
         "lang:hi": "जयपुर ग्रामीण लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jaipur Rural"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q6124378",
@@ -19656,7 +20406,7 @@
         "lang:hi": "जाजपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jajpur"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q6126633",
@@ -19681,7 +20431,7 @@
         "lang:hi": "जलंधर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jalandhar"
       },
-      "parent_id": null
+      "parent_id": "Q22424"
     },
     {
       "id": "Q6126683",
@@ -19706,7 +20456,7 @@
         "lang:hi": "जालौन लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jalaun"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q6126754",
@@ -19731,7 +20481,7 @@
         "lang:hi": "जलगांव लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jalgaon"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q6126930",
@@ -19756,7 +20506,7 @@
         "lang:hi": "जालना लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jalna"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q6126953",
@@ -19781,7 +20531,7 @@
         "lang:hi": "जालौर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jalore"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q6147990",
@@ -19806,7 +20556,7 @@
         "lang:hi": "जम्मू लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jammu"
       },
-      "parent_id": null
+      "parent_id": "Q1180"
     },
     {
       "id": "Q6148068",
@@ -19831,7 +20581,7 @@
         "lang:hi": "जामनगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jamnagar"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q6148213",
@@ -19856,7 +20606,7 @@
         "lang:hi": "जमशेदपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jamshedpur"
       },
-      "parent_id": null
+      "parent_id": "Q1184"
     },
     {
       "id": "Q6154054",
@@ -19881,7 +20631,7 @@
         "lang:hi": "जंगीपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jangipur"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q6154769",
@@ -19906,7 +20656,7 @@
         "lang:hi": "जांजगीर-चंपा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Janjgir"
       },
-      "parent_id": null
+      "parent_id": "Q1168"
     },
     {
       "id": "Q6164852",
@@ -19931,7 +20681,7 @@
         "lang:hi": "जौनपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jaunpur"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q6167862",
@@ -19956,7 +20706,7 @@
         "lang:hi": "जयनगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jaynagar (Lok Sabha constituency)"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q6190793",
@@ -19981,7 +20731,7 @@
         "lang:hi": "झालावाड़-बारां लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jhalawar-Baran"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q6190886",
@@ -20006,7 +20756,7 @@
         "lang:hi": "झंझारपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jhanjharpur"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q6190927",
@@ -20031,7 +20781,7 @@
         "lang:hi": "झाड़ग्राम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jhargram"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q6191216",
@@ -20056,7 +20806,7 @@
         "lang:hi": "झुंझुनू लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jhunjhunu"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q6207835",
@@ -20081,7 +20831,7 @@
         "lang:hi": "जोधपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jodhpur"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q6278852",
@@ -20106,7 +20856,7 @@
         "lang:hi": "जोरहाट लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Jorhat"
       },
-      "parent_id": null
+      "parent_id": "Q1164"
     },
     {
       "id": "Q6311592",
@@ -20131,7 +20881,7 @@
         "lang:hi": "जूनागढ़ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Junagadh"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q6344634",
@@ -20156,7 +20906,7 @@
         "lang:hi": "कच्छ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kachchh"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q6350138",
@@ -20181,7 +20931,7 @@
         "lang:hi": "कलाहांडी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kalahandi"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q6353510",
@@ -20206,7 +20956,7 @@
         "lang:hi": "कल्लाकुरिची लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kallakurichi"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q6362861",
@@ -20231,7 +20981,7 @@
         "lang:hi": "कांगड़ा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kangra"
       },
-      "parent_id": null
+      "parent_id": "Q1177"
     },
     {
       "id": "Q6368090",
@@ -20256,7 +21006,7 @@
         "lang:hi": "काराकाट लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Karakat"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q6368815",
@@ -20281,7 +21031,7 @@
         "lang:hi": "करौली-धौलपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Karauli–Dholpur"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q6372812",
@@ -20306,7 +21056,7 @@
         "lang:hi": "करनाल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Karnal"
       },
-      "parent_id": null
+      "parent_id": "Q1174"
     },
     {
       "id": "Q6378946",
@@ -20331,7 +21081,7 @@
         "lang:hi": "कौशांबी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kaushambi (Lok Sabha constituency)"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q6389017",
@@ -20356,7 +21106,7 @@
         "lang:hi": "केन्द्रपाड़ा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kendrapara"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q6398926",
@@ -20381,7 +21131,7 @@
         "lang:hi": "खडूर साहिब लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Khadoor Sahib"
       },
-      "parent_id": null
+      "parent_id": "Q22424"
     },
     {
       "id": "Q6398963",
@@ -20406,7 +21156,7 @@
         "lang:hi": "खगड़िया लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Khagaria"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q6401180",
@@ -20431,7 +21181,7 @@
         "lang:hi": "खेडा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kheda"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q6403035",
@@ -20456,7 +21206,7 @@
         "lang:hi": "खूँटी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Khunti"
       },
-      "parent_id": null
+      "parent_id": "Q1184"
     },
     {
       "id": "Q6425227",
@@ -20481,7 +21231,7 @@
         "lang:hi": "कोडरमा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kodarma"
       },
-      "parent_id": null
+      "parent_id": "Q1184"
     },
     {
       "id": "Q6427060",
@@ -20506,7 +21256,7 @@
         "lang:hi": "कोलार लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kolar"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q6427315",
@@ -20531,7 +21281,7 @@
         "lang:hi": "कोलकाता उत्तर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kolkata Uttar"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q6431426",
@@ -20556,7 +21306,7 @@
         "lang:hi": "कोरापुट लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Koraput"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q6431463",
@@ -20581,7 +21331,7 @@
         "lang:hi": "कोरबा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Korba"
       },
-      "parent_id": null
+      "parent_id": "Q1168"
     },
     {
       "id": "Q6433781",
@@ -20606,7 +21356,7 @@
         "lang:hi": "कोटा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Kota"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q6437565",
@@ -20631,7 +21381,7 @@
         "lang:hi": "कृषनगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Krishnanagar"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q6447358",
@@ -20656,7 +21406,7 @@
         "lang:hi": "कुरुक्षेत्र",
         "lang:en": "Kurukshetra"
       },
-      "parent_id": null
+      "parent_id": "Q1174"
     },
     {
       "id": "Q6479803",
@@ -20706,7 +21456,7 @@
         "lang:hi": "लालगंज लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Lalganj"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q6509948",
@@ -20731,7 +21481,7 @@
         "lang:hi": "बंगलौर दक्षिण लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Bangalore South"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q6528588",
@@ -20756,7 +21506,7 @@
         "lang:hi": "पुरी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Puri"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q6667970",
@@ -20780,6 +21530,56 @@
       "name": {
         "lang:hi": "लोहरदगा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Lohardaga"
+      },
+      "parent_id": "Q1184"
+    },
+    {
+      "id": "Q66743",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/territory:py"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q66743"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "union territory of India",
+        "lang:hi": "भारत के संघ राज्यक्षेत्र"
+      },
+      "name": {
+        "lang:hi": "पुदुच्चेरी",
+        "lang:en": "Puducherry"
+      },
+      "parent_id": "Q668"
+    },
+    {
+      "id": "Q668",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q668"
+        }
+      ],
+      "associated_wikidata_positions": [
+        "Q192711"
+      ],
+      "type": {
+        "lang:en": "country",
+        "lang:hi": "देश"
+      },
+      "name": {
+        "lang:hi": "भारत गणराज्य",
+        "lang:en": "Republic of India"
       },
       "parent_id": null
     },
@@ -20806,7 +21606,7 @@
         "lang:hi": "लखनऊ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Lucknow"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q6698772",
@@ -20831,7 +21631,7 @@
         "lang:hi": "लुधियाना लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ludhiana"
       },
-      "parent_id": null
+      "parent_id": "Q22424"
     },
     {
       "id": "Q6723526",
@@ -20856,7 +21656,7 @@
         "lang:hi": "मछलीशहर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Machhlishahr"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q6727220",
@@ -20881,7 +21681,7 @@
         "lang:hi": "माधा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Madha"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q6727343",
@@ -20906,7 +21706,7 @@
         "lang:hi": "मधेपुरा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Madhepura"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q6732720",
@@ -20931,7 +21731,7 @@
         "lang:hi": "महबूबाबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mahabubabad"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     },
     {
       "id": "Q6733273",
@@ -20956,7 +21756,7 @@
         "lang:hi": "महराजगंज (बिहार) लोकसभा निर्वाचन क्षेत्र",
         "lang:en": "Maharajganj (Bihar)"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q6733274",
@@ -20981,7 +21781,7 @@
         "lang:hi": "महाराजगंज लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Maharajganj"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q6733840",
@@ -21006,7 +21806,7 @@
         "lang:hi": "मेहसाना लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mahesana"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q6736725",
@@ -21031,7 +21831,7 @@
         "lang:hi": "मैनपुरी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mainpuri"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q6741311",
@@ -21056,7 +21856,7 @@
         "lang:hi": "मलप्पुरम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Malappuram"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q6742775",
@@ -21081,7 +21881,7 @@
         "lang:hi": "मालदह दक्षिण लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Maldaha Dakshin"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q6742776",
@@ -21106,7 +21906,7 @@
         "lang:hi": "मालदह उत्तर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Maldaha Uttar"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q6743862",
@@ -21131,7 +21931,7 @@
         "lang:hi": "मल्काजगिरि लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Malkajgiri"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     },
     {
       "id": "Q6748042",
@@ -21156,7 +21956,7 @@
         "lang:hi": "मंडी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mandi"
       },
-      "parent_id": null
+      "parent_id": "Q1177"
     },
     {
       "id": "Q6748216",
@@ -21181,7 +21981,32 @@
         "lang:hi": "मंदसौर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mandsaur"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
+    },
+    {
+      "id": "Q677037",
+      "identifiers": [
+        {
+          "scheme": "MS_FB",
+          "identifier": "country:in/state:tg"
+        },
+        {
+          "scheme": "wikidata",
+          "identifier": "Q677037"
+        }
+      ],
+      "associated_wikidata_positions": [
+
+      ],
+      "type": {
+        "lang:en": "state of India",
+        "lang:hi": "भारतीय राज्य"
+      },
+      "name": {
+        "lang:hi": "तेलंगाना",
+        "lang:en": "Telangana"
+      },
+      "parent_id": "Q668"
     },
     {
       "id": "Q6787367",
@@ -21206,7 +22031,7 @@
         "lang:hi": "मथुरापुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mathurapur"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q6794117",
@@ -21231,7 +22056,7 @@
         "lang:hi": "मावल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Maval"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q6798125",
@@ -21256,7 +22081,7 @@
         "lang:hi": "मयूरभंज लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mayurbhanj"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q6806969",
@@ -21281,7 +22106,7 @@
         "lang:hi": "मेदिनीपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Medinipur"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q6874958",
@@ -21306,7 +22131,7 @@
         "lang:hi": "मिर्जापुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mirzapur"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q6875956",
@@ -21331,7 +22156,7 @@
         "lang:hi": "मिसरिख लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Misrikh"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q6935304",
@@ -21356,7 +22181,7 @@
         "lang:hi": "मुम्बई-उत्तर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mumbai North"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q6935308",
@@ -21381,7 +22206,7 @@
         "lang:hi": "मुम्बई उत्तर-मध्य लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mumbai North Central"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q6935309",
@@ -21406,7 +22231,7 @@
         "lang:hi": "मुम्बई उत्तर-पूर्व लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mumbai North East"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q6935311",
@@ -21431,7 +22256,7 @@
         "lang:hi": "मुंबई उत्तर-पश्चिम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mumbai North West"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q6935325",
@@ -21456,7 +22281,7 @@
         "lang:hi": "मुम्बई दक्षिण-मध्य लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Mumbai South Central"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q6939683",
@@ -21481,7 +22306,7 @@
         "lang:hi": "मुर्शिदाबाद लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Murshidabad"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q6956755",
@@ -21506,7 +22331,7 @@
         "lang:hi": "नबरंगपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nabarangpur"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q6958697",
@@ -21531,7 +22356,7 @@
         "lang:hi": "नागौर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nagaur"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q6958833",
@@ -21556,7 +22381,7 @@
         "lang:hi": "नगीना लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nagina"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q6959714",
@@ -21581,7 +22406,7 @@
         "lang:hi": "नैनीताल-ऊधमसिंह नगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nainital-Udhamsingh Nagar"
       },
-      "parent_id": null
+      "parent_id": "Q1499"
     },
     {
       "id": "Q6960794",
@@ -21606,7 +22431,7 @@
         "lang:hi": "नालन्दा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nalanda"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q6961238",
@@ -21631,7 +22456,7 @@
         "lang:hi": "नामाक्कल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Namakkal"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q6963393",
@@ -21656,7 +22481,7 @@
         "lang:hi": "नन्दुरबार लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nandurbar"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q6966848",
@@ -21681,7 +22506,7 @@
         "lang:hi": "नासिक लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Nashik"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q6982569",
@@ -21706,7 +22531,7 @@
         "lang:hi": "नवसारी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Navsari"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q7055185",
@@ -21731,7 +22556,7 @@
         "lang:hi": "उत्तर पूर्वी दिल्ली लोकसभा निर्वाचन क्षेत्र",
         "lang:en": "North East Delhi"
       },
-      "parent_id": null
+      "parent_id": "Q1353"
     },
     {
       "id": "Q7057245",
@@ -21756,7 +22581,7 @@
         "lang:hi": "उत्तर पश्चिम दिल्ली लोकसभा निर्वाचन क्षेत्र",
         "lang:en": "North West Delhi"
       },
-      "parent_id": null
+      "parent_id": "Q1353"
     },
     {
       "id": "Q7111989",
@@ -21781,7 +22606,7 @@
         "lang:hi": "बाहरी मणिपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Outer Manipur"
       },
-      "parent_id": null
+      "parent_id": "Q1193"
     },
     {
       "id": "Q7127479",
@@ -21806,7 +22631,7 @@
         "lang:hi": "पालघर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Palghar"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q7127504",
@@ -21831,7 +22656,7 @@
         "lang:hi": "पाली लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Pali"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q7130343",
@@ -21856,7 +22681,7 @@
         "lang:hi": "पंचमहल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Panchmahal"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q7141801",
@@ -21881,7 +22706,7 @@
         "lang:hi": "पश्चिम चम्पारण लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Paschim Champaran"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q7144222",
@@ -21906,7 +22731,7 @@
         "lang:hi": "पाटलिपुत्र लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Pataliputra"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q7144231",
@@ -21931,7 +22756,7 @@
         "lang:hi": "पाटन लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Patan"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q7144692",
@@ -21956,7 +22781,7 @@
         "lang:hi": "पथनमथीट्टा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Pathanamthitta"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q7144911",
@@ -21981,7 +22806,7 @@
         "lang:hi": "पटियाला लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Patiala"
       },
-      "parent_id": null
+      "parent_id": "Q22424"
     },
     {
       "id": "Q7145114",
@@ -22006,7 +22831,7 @@
         "lang:hi": "पटना साहिब लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Patna Sahib (Lok Sabha constituency)"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q7188338",
@@ -22031,7 +22856,7 @@
         "lang:hi": "फूलपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Phulpur"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q7193997",
@@ -22056,7 +22881,7 @@
         "lang:hi": "पीलीभीत लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Pilibhit"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q7229961",
@@ -22081,7 +22906,7 @@
         "lang:hi": "पोरबंदर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Porbandar"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q7238619",
@@ -22106,7 +22931,7 @@
         "lang:hi": "प्रतापगढ़ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Pratapgarh"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q7255284",
@@ -22131,7 +22956,7 @@
         "lang:hi": "बरहमपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Berhampur"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q7255845",
@@ -22156,7 +22981,7 @@
         "lang:hi": "सम्बलपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sambalpur"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q7260097",
@@ -22181,7 +23006,7 @@
         "lang:hi": "पुणे लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Pune"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q7261625",
@@ -22206,7 +23031,7 @@
         "lang:hi": "पुरूलिया लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Purulia"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q7261669",
@@ -22231,7 +23056,7 @@
         "lang:hi": "पूर्वी चम्पारण लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Purvi Champaran"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q7281907",
@@ -22256,7 +23081,7 @@
         "lang:hi": "रायबरेली लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Rae Bareli"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q7283812",
@@ -22281,7 +23106,7 @@
         "lang:hi": "रायगड लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Raigad"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q7283824",
@@ -22306,7 +23131,7 @@
         "lang:hi": "रायगड लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Raigarh"
       },
-      "parent_id": null
+      "parent_id": "Q1168"
     },
     {
       "id": "Q7286307",
@@ -22331,7 +23156,7 @@
         "lang:hi": "राजमहल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Rajmahal"
       },
-      "parent_id": null
+      "parent_id": "Q1184"
     },
     {
       "id": "Q7286332",
@@ -22356,7 +23181,7 @@
         "lang:hi": "राजनन्दगांव लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Rajnandgaon"
       },
-      "parent_id": null
+      "parent_id": "Q1168"
     },
     {
       "id": "Q7286417",
@@ -22381,7 +23206,7 @@
         "lang:hi": "राजसमन्द लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Rajsamand"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q7290061",
@@ -22406,7 +23231,7 @@
         "lang:hi": "रामपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Rampur"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q7290693",
@@ -22431,7 +23256,7 @@
         "lang:hi": "राणाघाट लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ranaghat"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q7290802",
@@ -22456,7 +23281,7 @@
         "lang:hi": "राँची लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ranchi"
       },
-      "parent_id": null
+      "parent_id": "Q1184"
     },
     {
       "id": "Q7295816",
@@ -22481,7 +23306,7 @@
         "lang:hi": "रतलाम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ratlam"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q7296597",
@@ -22506,7 +23331,7 @@
         "lang:hi": "रावेर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Raver"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q7319005",
@@ -22531,7 +23356,7 @@
         "lang:hi": "रीवा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Rewa"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q7352073",
@@ -22556,7 +23381,7 @@
         "lang:hi": "रॉबर्ट्सगंज लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Robertsganj"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q7359839",
@@ -22581,7 +23406,7 @@
         "lang:hi": "रोहतक लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Rohtak"
       },
-      "parent_id": null
+      "parent_id": "Q1174"
     },
     {
       "id": "Q7395911",
@@ -22606,7 +23431,7 @@
         "lang:hi": "साबरकंठा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sabarkantha"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q7399007",
@@ -22631,7 +23456,7 @@
         "lang:hi": "सागर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sagar"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q7399517",
@@ -22656,7 +23481,7 @@
         "lang:hi": "सहारनपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Saharanpur"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q7408890",
@@ -22681,7 +23506,7 @@
         "lang:hi": "समस्तीपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Samastipur"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q7409031",
@@ -22706,7 +23531,7 @@
         "lang:hi": "संभल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sambhal"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q7418045",
@@ -22731,7 +23556,7 @@
         "lang:hi": "सांगली लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sangli"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q7418135",
@@ -22756,7 +23581,7 @@
         "lang:hi": "संगरूर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sangrur"
       },
-      "parent_id": null
+      "parent_id": "Q22424"
     },
     {
       "id": "Q7419095",
@@ -22781,7 +23606,7 @@
         "lang:hi": "सन्त कबीर नगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sant Kabir Nagar"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q7423046",
@@ -22806,7 +23631,7 @@
         "lang:hi": "सारण लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Saran"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q7461799",
@@ -22831,7 +23656,7 @@
         "lang:hi": "शाहजहाँपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Shahjahanpur"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q7494394",
@@ -22856,7 +23681,7 @@
         "lang:hi": "शिवहर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sheohar"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q7496680",
@@ -22881,7 +23706,7 @@
         "lang:hi": "शिलांग लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Shillong (Lok Sabha constituency)"
       },
-      "parent_id": null
+      "parent_id": "Q1195"
     },
     {
       "id": "Q7496887",
@@ -22906,7 +23731,7 @@
         "lang:hi": "शिमला लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Shimla"
       },
-      "parent_id": null
+      "parent_id": "Q1177"
     },
     {
       "id": "Q7499000",
@@ -22931,7 +23756,7 @@
         "lang:hi": "शिरूर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Shirur"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q7503442",
@@ -22956,7 +23781,7 @@
         "lang:hi": "श्रावस्ती लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Shrawasti"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q7508585",
@@ -22981,7 +23806,7 @@
         "lang:hi": "सीधी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sidhi"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q7513596",
@@ -23006,7 +23831,7 @@
         "lang:hi": "सीकर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sikar"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q7530618",
@@ -23031,7 +23856,7 @@
         "lang:hi": "सिरसा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sirsa"
       },
-      "parent_id": null
+      "parent_id": "Q1174"
     },
     {
       "id": "Q7531640",
@@ -23056,7 +23881,7 @@
         "lang:hi": "सीतामढ़ी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sitamarhi"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q7532526",
@@ -23081,7 +23906,7 @@
         "lang:hi": "सीवान लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Siwan"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q7561886",
@@ -23106,7 +23931,7 @@
         "lang:hi": "सोनीपत लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sonipat"
       },
-      "parent_id": null
+      "parent_id": "Q1174"
     },
     {
       "id": "Q7567023",
@@ -23131,7 +23956,7 @@
         "lang:hi": "दक्षिण दिल्ली",
         "lang:en": "South Delhi"
       },
-      "parent_id": null
+      "parent_id": "Q1353"
     },
     {
       "id": "Q7567370",
@@ -23156,7 +23981,7 @@
         "lang:hi": "दक्षिण गोवा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "South Goa"
       },
-      "parent_id": null
+      "parent_id": "Q1171"
     },
     {
       "id": "Q7585738",
@@ -23181,7 +24006,7 @@
         "lang:hi": "सेरमपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sreerampur"
       },
-      "parent_id": null
+      "parent_id": "Q1356"
     },
     {
       "id": "Q7586418",
@@ -23206,7 +24031,7 @@
         "lang:hi": "श्रीनगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Srinagar"
       },
-      "parent_id": null
+      "parent_id": "Q1180"
     },
     {
       "id": "Q7636812",
@@ -23231,7 +24056,7 @@
         "lang:hi": "सुल्तानपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sultanpur"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q7639274",
@@ -23256,7 +24081,7 @@
         "lang:hi": "सुन्दरगढ़ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Sundargarh"
       },
-      "parent_id": null
+      "parent_id": "Q22048"
     },
     {
       "id": "Q7645435",
@@ -23281,7 +24106,7 @@
         "lang:hi": "सूरत लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Surat"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q7645700",
@@ -23306,7 +24131,7 @@
         "lang:hi": "सुरेन्द्रनगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Surendranagar"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q7694914",
@@ -23331,7 +24156,7 @@
         "lang:hi": "टिहरी गढ़वाल लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Tehri Garhwal"
       },
-      "parent_id": null
+      "parent_id": "Q1499"
     },
     {
       "id": "Q7710231",
@@ -23356,7 +24181,7 @@
         "lang:hi": "ठाणे लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Thane"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q7781368",
@@ -23381,7 +24206,7 @@
         "lang:hi": "थेनी लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Theni"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q7785493",
@@ -23406,7 +24231,7 @@
         "lang:hi": "तिरुवल्लूर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Thiruvallur"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q7785502",
@@ -23431,7 +24256,7 @@
         "lang:hi": "तिरुवनन्तपुरम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Thiruvananthapuram"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q7801879",
@@ -23456,7 +24281,7 @@
         "lang:hi": "टीकमगढ़ लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Tikamgarh"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q7809406",
@@ -23481,7 +24306,7 @@
         "lang:hi": "तिरूप्पुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Tiruppur"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q7809457",
@@ -23506,7 +24331,7 @@
         "lang:hi": "तिरुवन्नामलाई लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Tiruvannamalai"
       },
-      "parent_id": null
+      "parent_id": "Q1445"
     },
     {
       "id": "Q7821522",
@@ -23531,7 +24356,7 @@
         "lang:hi": "टोंक-सवाई माधोपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Tonk-Sawai Madhopur"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q7843852",
@@ -23556,7 +24381,7 @@
         "lang:hi": "त्रिपुरा पूर्व लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Tripura East"
       },
-      "parent_id": null
+      "parent_id": "Q1363"
     },
     {
       "id": "Q7843879",
@@ -23581,7 +24406,7 @@
         "lang:hi": "त्रिपुरा पश्चिम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Tripura West"
       },
-      "parent_id": null
+      "parent_id": "Q1363"
     },
     {
       "id": "Q7853631",
@@ -23606,7 +24431,7 @@
         "lang:hi": "तुरा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Tura (Lok Sabha constituency)"
       },
-      "parent_id": null
+      "parent_id": "Q1195"
     },
     {
       "id": "Q7876885",
@@ -23631,7 +24456,7 @@
         "lang:hi": "उदयपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Udaipur"
       },
-      "parent_id": null
+      "parent_id": "Q1437"
     },
     {
       "id": "Q7877193",
@@ -23656,7 +24481,7 @@
         "lang:hi": "उधमपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Udhampur"
       },
-      "parent_id": null
+      "parent_id": "Q1180"
     },
     {
       "id": "Q7877355",
@@ -23681,7 +24506,7 @@
         "lang:hi": "उदुपी चिकमगलूर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Udupi Chikmagalur"
       },
-      "parent_id": null
+      "parent_id": "Q1185"
     },
     {
       "id": "Q7878191",
@@ -23706,7 +24531,7 @@
         "lang:hi": "उजियारपुर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Ujiarpur"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q7897148",
@@ -23731,7 +24556,7 @@
         "lang:hi": "उन्नाव लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Unnao"
       },
-      "parent_id": null
+      "parent_id": "Q1498"
     },
     {
       "id": "Q7908337",
@@ -23756,7 +24581,7 @@
         "lang:hi": "वडोदरा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Vadodara"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q7908854",
@@ -23781,7 +24606,7 @@
         "lang:hi": "वैशाली लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Vaishali"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q7912496",
@@ -23806,7 +24631,7 @@
         "lang:hi": "वाल्मीकि नगर लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Valmiki Nagar"
       },
-      "parent_id": null
+      "parent_id": "Q1165"
     },
     {
       "id": "Q7912607",
@@ -23831,7 +24656,7 @@
         "lang:hi": "वलसाड लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Valsad"
       },
-      "parent_id": null
+      "parent_id": "Q1061"
     },
     {
       "id": "Q7928100",
@@ -23856,7 +24681,7 @@
         "lang:hi": "विदिशा लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Vidisha"
       },
-      "parent_id": null
+      "parent_id": "Q1188"
     },
     {
       "id": "Q7938017",
@@ -23881,7 +24706,7 @@
         "lang:hi": "विजियानगरम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Vizianagaram"
       },
-      "parent_id": null
+      "parent_id": "Q1159"
     },
     {
       "id": "Q7975848",
@@ -23906,7 +24731,7 @@
         "lang:hi": "वयनाड लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Wayanad"
       },
-      "parent_id": null
+      "parent_id": "Q1186"
     },
     {
       "id": "Q7984938",
@@ -23931,7 +24756,7 @@
         "lang:hi": "पश्चिम दिल्ली लोकसभा निर्वाचन क्षेत्र",
         "lang:en": "West Delhi"
       },
-      "parent_id": null
+      "parent_id": "Q1353"
     },
     {
       "id": "Q8050386",
@@ -23956,7 +24781,7 @@
         "lang:hi": "यवतमाल-वाशिम लोक सभा निर्वाचन क्षेत्र",
         "lang:en": "Yavatmal-Washim"
       },
-      "parent_id": null
+      "parent_id": "Q1191"
     },
     {
       "id": "Q8064692",
@@ -23981,7 +24806,7 @@
         "lang:hi": "ज़हीराबाद लोक सभा निर्वाचन क्षेत्र सम्पादन",
         "lang:en": "Zahirabad"
       },
-      "parent_id": null
+      "parent_id": "Q677037"
     }
   ],
   "memberships": [


### PR DESCRIPTION
They're the parent area of Lok Sabha constituencies but we
don't yet want to include their roles in the data build.